### PR TITLE
return APIError on 429 Too Many Requests

### DIFF
--- a/api.go
+++ b/api.go
@@ -301,11 +301,15 @@ func (s *API) handleHTTPError(goodStatusCode []int, resp *http.Response) ([]byte
 	}
 	if !good {
 		var scwError APIError
+		scwError.StatusCode = resp.StatusCode
+		if resp.StatusCode == 429 {
+			return nil, scwError
+		}
 
 		if err := json.Unmarshal(body, &scwError); err != nil {
 			return nil, err
 		}
-		scwError.StatusCode = resp.StatusCode
+
 		return nil, scwError
 	}
 	return body, nil


### PR DESCRIPTION
Scaleway API returns HTTP status 429 Too Many Requests
when the rate limit is reached. This error does not
contain a JSON payload, which results in a unhelpful
`unexpected end of JSON input` error message.

This change returns a ScalewayAPIError in this case
with the StatusCode set.