### PR TITLE
Add objectstore support

### DIFF
--- a/api.go
+++ b/api.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
@@ -27,11 +28,12 @@ import (
 // https://cp-ams1.scaleway.com/products/servers
 // Default values
 var (
-	AccountAPI     = "https://account.scaleway.com/"
-	MetadataAPI    = "http://169.254.42.42/"
-	MarketplaceAPI = "https://api-marketplace.scaleway.com"
-	ComputeAPIPar1 = "https://cp-par1.scaleway.com/"
-	ComputeAPIAms1 = "https://cp-ams1.scaleway.com/"
+	AccountAPI           = "https://account.scaleway.com/"
+	MetadataAPI          = "http://169.254.42.42/"
+	MarketplaceAPI       = "https://api-marketplace.scaleway.com"
+	ComputeAPIPar1       = "https://cp-par1.scaleway.com/"
+	ComputeAPIAms1       = "https://cp-ams1.scaleway.com/"
+	ObjectStorageAPIAms1 = "https://sis-ams1.scaleway.com"
 
 	URLPublicDNS  = ".pub.cloud.scaleway.com"
 	URLPrivateDNS = ".priv.cloud.scaleway.com"
@@ -64,9 +66,10 @@ type API struct {
 	Token        string     // Token is the authentication token for the  organization
 	Client       HTTPClient // Client is used for all HTTP interactions
 
-	password   string // Password is the authentication password
-	userAgent  string
-	computeAPI string
+	password       string // Password is the authentication password
+	userAgent      string
+	computeAPI     string
+	objectstoreAPI string
 
 	Region string
 }
@@ -120,14 +123,19 @@ func New(organization, token, region string, options ...func(*API)) (*API, error
 	switch region {
 	case "par1", "":
 		s.computeAPI = ComputeAPIPar1
+		s.objectstoreAPI = ""
 	case "ams1":
 		s.computeAPI = ComputeAPIAms1
+		s.objectstoreAPI = ObjectStorageAPIAms1
 	default:
 		return nil, fmt.Errorf("%s isn't a valid region", region)
 	}
 	s.Region = region
 	if url := os.Getenv("SCW_COMPUTE_API"); url != "" {
 		s.computeAPI = url
+	}
+	if url := os.Getenv("SCW_OBJECTSTORE_API"); url != "" {
+		s.objectstoreAPI = url
 	}
 	return s, nil
 }
@@ -235,6 +243,37 @@ func (s *API) GetResponsePaginate(apiURL, resource string, values url.Values) (*
 		resp, err = s.response("GET", fmt.Sprintf("%s/%s?%s", strings.TrimRight(apiURL, "/"), resource, values.Encode()), nil)
 	}
 	return resp, err
+}
+
+func (s *API) Upload(apiURL, resource, name string, data io.Reader) (resp *http.Response, err error) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", name)
+	if err != nil {
+		return nil, err
+	}
+	_, err = io.Copy(part, data)
+
+	params := map[string]string{}
+	for key, val := range params {
+		_ = writer.WriteField(key, val)
+	}
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	uri := fmt.Sprintf("%s/%s", strings.TrimRight(apiURL, "/"), resource)
+	req, err := http.NewRequest("POST", uri, body)
+	if err != nil {
+		err = fmt.Errorf("response %s %s", "POST", uri)
+		return
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("X-Auth-Token", s.Token)
+	req.Header.Set("User-Agent", s.userAgent)
+	resp, err = s.Client.Do(req)
+	return
 }
 
 // PostResponse returns an http.Response object for the updated resource

--- a/api_test.go
+++ b/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"log"
 	"os"
 	"testing"
@@ -8,15 +9,22 @@ import (
 
 var client *API
 
-func TestMain(m *testing.M) {
-	if os.Getenv("SCALEWAY_ORGANIZATION") != "" && os.Getenv("SCALEWAY_TOKEN") != "" {
-		c, err := New(os.Getenv("SCALEWAY_ORGANIZATION"), os.Getenv("SCALEWAY_TOKEN"), "par1")
-		if err != nil {
-			log.Printf("Unable to create scaleway client")
-			os.Exit(1)
-		}
-		client = c
+var errMissingCredentials = errors.New("Missing SCALEWAY_ORGANIZATION and/or SCALEWAY_TOKEN environment variable")
+
+func buildClient(region string) (*API, error) {
+	if os.Getenv("SCALEWAY_ORGANIZATION") == "" || os.Getenv("SCALEWAY_TOKEN") == "" {
+		return nil, errMissingCredentials
 	}
+	return New(os.Getenv("SCALEWAY_ORGANIZATION"), os.Getenv("SCALEWAY_TOKEN"), region)
+}
+
+func TestMain(m *testing.M) {
+	c, err := buildClient("par1")
+	if err != nil && err != errMissingCredentials {
+		log.Printf("Unable to create scaleway client")
+		os.Exit(1)
+	}
+	client = c
 	code := m.Run()
 	os.Exit(code)
 }

--- a/container.go
+++ b/container.go
@@ -2,31 +2,175 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 )
 
-// ContainerData represents a  container data (S3)
-type ContainerData struct {
+// Object represents a  container data (S3)
+type Object struct {
 	LastModified string `json:"last_modified"`
 	Name         string `json:"name"`
 	Size         string `json:"size"`
-}
-
-type getContainerDatas struct {
-	Container []*ContainerData `json:"container"`
+	Public       bool   `json:"public"`
 }
 
 // Container represents a  container (S3)
 type Container struct {
-	Organization `json:"organization"`
-	Name         string `json:"name"`
-	Size         string `json:"size"`
+	Organization    `json:"organization"`
+	Name            string `json:"name"`
+	Size            int    `json:"size,string"`
+	NumberOfObjects int    `json:"num_objects,string"`
+	Public          bool   `json:"public"`
 }
 
-type getContainers struct {
-	Containers []*Container `json:"containers"`
+// CreateBucketRequest is used to create new buckets
+type CreateBucketRequest struct {
+	Name         string `json:"name"`
+	Organization string `json:"organization"`
+}
+
+// ErrRegionNotYetSupported is returned to indicate that the selected region does not support buckets yet
+var ErrRegionNotYetSupported = errors.New("Only the AMS1 region is supported at the moment")
+
+// PutObjectRequest uploads an object into an bucket
+type PutObjectRequest struct {
+	BucketName string
+	ObjectName string
+}
+
+// ListObjects lists all objects in a bucket
+func (s *API) ListObjects(bucket string) ([]*Object, error) {
+	vs := url.Values{}
+	vs.Set("delimiter", "/")
+	vs.Set("prefix", "")
+	resp, err := s.GetResponsePaginate(s.objectstoreAPI, fmt.Sprintf("containers/%s", bucket), vs)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := s.handleHTTPError([]int{http.StatusOK}, resp)
+	if err != nil {
+		return nil, err
+	}
+	type listObjectsResponse struct {
+		Containers []*Object `json:"container"`
+	}
+	var containers listObjectsResponse
+
+	if err = json.Unmarshal(body, &containers); err != nil {
+		return nil, err
+	}
+	return containers.Containers, nil
+}
+
+// GetObject fetches a single object from a bucket
+func (s *API) GetObject(bucket, name string) (*Object, error) {
+	resp, err := s.GetResponsePaginate(s.objectstoreAPI, fmt.Sprintf("containers/%s/%s", bucket, name), url.Values{})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := s.handleHTTPError([]int{http.StatusOK}, resp)
+	if err != nil {
+		return nil, err
+	}
+	type getObjectResponse struct {
+		Container *Object `json:"object"`
+	}
+	var containers getObjectResponse
+
+	if err = json.Unmarshal(body, &containers); err != nil {
+		return nil, err
+	}
+	return containers.Container, nil
+}
+
+// PutObject uploads a file into a bucket
+func (s *API) PutObject(req *PutObjectRequest, r io.Reader) (*Object, error) {
+	if s.objectstoreAPI == "" {
+		return nil, ErrRegionNotYetSupported
+	}
+	resp, err := s.Upload(
+		s.objectstoreAPI,
+		fmt.Sprintf("containers/%s/upload/%s", req.BucketName, req.ObjectName),
+		req.ObjectName, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	_, err = s.handleHTTPError([]int{http.StatusNoContent}, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := s.GetObject(req.BucketName, req.ObjectName)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// DeleteObject removes an object from a bucket on scaleway SIS
+func (s *API) DeleteObject(bucket, name string) error {
+	if s.objectstoreAPI == "" {
+		return ErrRegionNotYetSupported
+	}
+	resp, err := s.DeleteResponse(s.objectstoreAPI, fmt.Sprintf("containers/%s/%s", bucket, name))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = s.handleHTTPError([]int{http.StatusNoContent}, resp)
+	return err
+}
+
+// CreateBucket creates a new scaleway SIS bucket
+func (s *API) CreateBucket(req *CreateBucketRequest) (*Container, error) {
+	type createBucketResponse struct {
+		Container `json:"container"`
+	}
+	if s.objectstoreAPI == "" {
+		return nil, ErrRegionNotYetSupported
+	}
+	resp, err := s.PostResponse(s.objectstoreAPI, "containers", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := s.handleHTTPError([]int{http.StatusOK}, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var container createBucketResponse
+	if err := json.Unmarshal(body, &container); err != nil {
+		return nil, err
+	}
+	return &container.Container, nil
+}
+
+// DeleteBucket removes a bucket on scaleway SIS
+func (s *API) DeleteBucket(name string) error {
+	if s.objectstoreAPI == "" {
+		return ErrRegionNotYetSupported
+	}
+	resp, err := s.DeleteResponse(s.objectstoreAPI, fmt.Sprintf("containers/%s", name))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = s.handleHTTPError([]int{http.StatusNoContent}, resp)
+	return err
 }
 
 // GetContainers returns a GetContainers
@@ -41,30 +185,14 @@ func (s *API) GetContainers() ([]*Container, error) {
 	if err != nil {
 		return nil, err
 	}
+	type getContainers struct {
+		Containers []*Container `json:"containers"`
+	}
+
 	var containers getContainers
 
 	if err = json.Unmarshal(body, &containers); err != nil {
 		return nil, err
 	}
 	return containers.Containers, nil
-}
-
-// GetContainerDatas returns a GetContainerDatas
-func (s *API) GetContainerDatas(container string) ([]*ContainerData, error) {
-	resp, err := s.GetResponsePaginate(s.computeAPI, fmt.Sprintf("containers/%s", container), url.Values{})
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := s.handleHTTPError([]int{http.StatusOK}, resp)
-	if err != nil {
-		return nil, err
-	}
-	var datas getContainerDatas
-
-	if err = json.Unmarshal(body, &datas); err != nil {
-		return nil, err
-	}
-	return datas.Container, nil
 }

--- a/container_test.go
+++ b/container_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func generateRandomBucketName() string {
+	return fmt.Sprintf("scaleway-test-%d-%s", time.Now().Unix(), fmt.Sprintf("%x", md5.Sum([]byte(time.Now().String()))))
+}
+
+func TestScalewaAPI_ManageBucket(t *testing.T) {
+	client, err := buildClient("ams1")
+	if err != nil {
+		t.Fatalf("Unable to create a client for AMS1: %v", err.Error())
+	}
+
+	desiredBucketName := generateRandomBucketName()
+	bucket, err := client.CreateBucket(&CreateBucketRequest{
+		Name:         desiredBucketName,
+		Organization: client.Organization,
+	})
+	if err != nil {
+		t.Fatalf("Expected request to succeed, but didn't: %v", err.Error())
+	}
+
+	defer func() {
+		client.DeleteBucket(desiredBucketName)
+	}()
+
+	if bucket.Name != desiredBucketName {
+		t.Errorf("Expected bucket name of %s, but got %s", desiredBucketName, bucket.Name)
+	}
+	if bucket.NumberOfObjects != 0 || bucket.Size != 0 {
+		t.Errorf("Expected to create a fresh bucket, but got %d items, %d size", bucket.NumberOfObjects, bucket.Size)
+	}
+}
+
+func TestScalewaAPI_ManageObject(t *testing.T) {
+	client, err := buildClient("ams1")
+	if err != nil {
+		t.Fatalf("Unable to create a client for AMS1: %v", err.Error())
+	}
+
+	bucket, err := client.CreateBucket(&CreateBucketRequest{
+		Name:         generateRandomBucketName(),
+		Organization: client.Organization,
+	})
+	if err != nil {
+		t.Fatalf("test requires bucket, but creation failed: %v", err.Error())
+	}
+
+	defer func() {
+		client.DeleteBucket(bucket.Name)
+	}()
+
+	desiredName := "just-a-test"
+	t.Run("Put object", func(t *testing.T) {
+		tmpfile := bytes.NewBuffer([]byte("temporary file's content"))
+
+		object, err := client.PutObject(&PutObjectRequest{
+			BucketName: bucket.Name,
+			ObjectName: desiredName,
+		}, tmpfile)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if object == nil {
+			t.Fatalf("Expected object, but got %v", object)
+		}
+		if object.Name != desiredName {
+			t.Fatalf("Expected %s as name, but got %s", desiredName, object.Name)
+		}
+	})
+	t.Run("Get object", func(t *testing.T) {
+		object, err := client.GetObject(bucket.Name, desiredName)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if object == nil {
+			t.Fatalf("Expected object, but got %v", object)
+		}
+		if object.Name != desiredName {
+			t.Fatalf("Expected %s as name, but got %s", desiredName, object.Name)
+		}
+	})
+	t.Run("List objects", func(t *testing.T) {
+		containers, err := client.ListObjects(bucket.Name)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		if len(containers) != 1 {
+			t.Fatalf("Expected 1 object, got %d", len(containers))
+		}
+	})
+	t.Run("Delete objects", func(t *testing.T) {
+		err := client.DeleteObject(bucket.Name, desiredName)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		containers, err := client.ListObjects(bucket.Name)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if len(containers) != 0 {
+			t.Fatalf("Expected 0 object, got %d", len(containers))
+		}
+	})
+}


### PR DESCRIPTION
Scaleway recently opened up their objectstore api again.
The details are listed on the official page: https://www.scaleway.com/object-storage/

this PR implements the required methods to add support for this in
terraform

Scaleway recently opened up their storage API again.
See https://www.scaleway.com/object-storage/ for details.